### PR TITLE
Updated bash/bat commands for newer geth init method

### DIFF
--- a/init.bat
+++ b/init.bat
@@ -1,0 +1,1 @@
+geth --rpc --networkid=39318 --maxpeers=0 --datadir=devChain --verbosity 0 init genesis_dev.json

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,1 @@
+geth --rpc --networkid=39318 --maxpeers=0 --datadir=devChain --verbosity 0 init genesis_dev.json

--- a/startgeth.bat
+++ b/startgeth.bat
@@ -1,1 +1,1 @@
-geth --rpc --networkid=39318 --maxpeers=0 --datadir=devChain --genesis genesis_dev.json --verbosity 0 console
+geth --rpc --networkid=39318 --maxpeers=0 --datadir=devChain --verbosity 0 console

--- a/startgeth.sh
+++ b/startgeth.sh
@@ -1,1 +1,1 @@
-geth --rpc --networkid=39318 --maxpeers=0 --datadir=devChain --genesis genesis_dev.json --verbosity 0 console
+geth --rpc --networkid=39318 --maxpeers=0 --datadir=devChain --verbosity 0 console 


### PR DESCRIPTION
geth no longer supports the --genesis parameter. You have to call it first with init <genesis json> and then start it normally.
